### PR TITLE
Disable disqus templates if DisqusShortname is not set

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,6 +36,7 @@
 				{{ end }}
 			</div>
 
+			{{- if .Site.DisqusShortname -}}
 			{{- $.Scratch.Set "isDisqus" true -}}
 
 			{{- if and (isset .Params "type") (in .Site.Params.disableDisqusTypes .Params.type) -}}
@@ -50,6 +51,7 @@
 
 			{{- if eq ($.Scratch.Get "isDisqus") true -}}
 			{{- partial "disqus.html" . -}}
+			{{- end -}}
 			{{- end -}}
 		</div>
 	</div>


### PR DESCRIPTION
If the Disqus shortname isn't set then the user obviously doesn't want to use
disqus, so skip the template entirely.