### PR TITLE
Fix double ouput of 'comments powered by Disqus.'

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -12,6 +12,5 @@
 		(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 	})();
 </script>
-<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by
-		Disqus.</a></noscript>
+<noscript>Please enable JavaScript to view the </a></noscript>
 <a href="http://disqus.com/" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>


### PR DESCRIPTION
If JavaScript is disabled in a web-browser, the message 'comments powered
by Disqus' is doubled.

This issue occurs because the output of the text is additionally appears in
the \<noscript> area for JavaScript.

The text in the \<noscript> area is deleted so that the Information
appears correct when JavaScript is disabled.