### PR TITLE
fix: use block for `li`

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -156,7 +156,7 @@ ul.flat {
 }
 
 ul.flat li {
-    display: inline-block;
+    display: block;
     list-style: none;
     margin-left: 0;
 }


### PR DESCRIPTION
In the `all` posts listings page, if there are multiple `li` elements, both are wrapped in one row because of `display:inline-block`. This is an edge case, probably happens if multiple elements of different widths combined, can fit in the width of the entire container.

Ideally all posts/tag listing should be one/line, so `display:block` is the correct property to be used.

![image](https://user-images.githubusercontent.com/5689132/72215910-b559e280-353f-11ea-9f82-c9398cff363f.png)
