### PR TITLE
Add year to footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <div class="footer wrapper">
 	<nav class="nav">
-		<div>{{ with .Site.Copyright }} {{ . | safeHTML }} | {{ end }} <a href="https://github.com/knadh/hugo-ink">Ink</a> theme on <a href="https://gohugo.io">Hugo</a></div>
+		<div>{{ .Date.Year}} {{ with .Site.Copyright }} {{ . | safeHTML }} | {{ end }} <a href="https://github.com/knadh/hugo-ink">Ink</a> theme on <a href="https://gohugo.io">Hugo</a></div>
 	</nav>
 </div>
 


### PR DESCRIPTION
The copyright part of the footer ought to contain a year. Currently, this has to be manually inserted. This tweak removes the manual part and inserts the  current year to the footer.

Thanks for making this theme 😄