### PR TITLE
Include _internal/schema template to header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,6 +18,7 @@
 		{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 	{{ end -}}
 
+	{{- template "_internal/schema.html" . -}}
 	{{- template "_internal/opengraph.html" . -}}
 	{{- template "_internal/twitter_cards.html" . -}}
 	<link href='https://fonts.googleapis.com/css?family=Playfair+Display:700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
I noticed that [my website](https://ieftimov.com) was missing some `meta` descriptions, so I started digging around. Found out that the `header.html` template is missing is not rendering the embedded [`schema` template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/schema.html).

I believe it should be included, since it produces some useful `meta` tags, such as:

```
<meta itemprop="name" content="Understanding bytes in Go by building a TCP protocol">
<meta itemprop="description" content="Learn everything you need to know to work with bytes and slices of bytes ([]byte) by building a chat TCP-based protocol.">
<meta itemprop="datePublished" content="2020-04-02T00:00:00+00:00">
<meta itemprop="dateModified" content="2020-04-02T00:00:00+00:00">
<meta itemprop="wordCount" content="5720">
<meta itemprop="image" content="http://localhost:1313/cards/understanding-bytes-golang-build-tcp-protocol.gif">
<meta itemprop="keywords" content="">
```

Thank you for the nice theme, and keep up the great work! 🙇 