### PR TITLE
Add dark mode toggle to site header

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,6 +18,9 @@
 				{{- end -}}
 			</ul>
 		</nav>
+                {{- if or (eq .Site.Params.mode "auto") (eq .Site.Params.mode "dark") -}}
+                <span class="scheme-toggle"><a href="#" id="scheme-toggle"></a>
+                {{- end -}}
 	</div>
 
 	<nav class="nav">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -28,9 +28,9 @@
 		<link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}{{ .Site.Params.customCSS }}" />
 	{{ end }}
 	{{- if or (eq .Site.Params.mode "auto") (eq .Site.Params.mode "dark") -}}
-		<link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}css/dark.css" {{ if eq .Site.Params.mode "auto" }}media="(prefers-color-scheme: dark)"{{ end }} />
+		<link id="dark-scheme" rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}css/dark.css" {{ if eq .Site.Params.mode "auto" }}media="(prefers-color-scheme: dark)"{{ end }} />
 		{{- if isset .Site.Params "customdarkcss" }}
-			<link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}{{ .Site.Params.customDarkCSS }}" {{ if eq .Site.Params.mode "auto" }}media="(prefers-color-scheme: dark)"{{ end }} />
+			<link id="dark-scheme" rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}{{ .Site.Params.customDarkCSS }}" {{ if eq .Site.Params.mode "auto" }}media="(prefers-color-scheme: dark)"{{ end }} />
 		{{- end }}
 	{{- end }}
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -270,6 +270,24 @@ ul {
     max-height: 15px;
 }
 
+.header .site-description .scheme-toggle {
+    height: 100%;
+}
+
+.header .site-description .scheme-toggle a svg {
+    max-height: 15px;
+}
+
+.header .site-description .scheme-toggle a.dark svg {
+    fill: #f8e04f;
+    color: #f8e04f;
+}
+
+.header .site-description .scheme-toggle a.light svg {
+    fill: grey;
+    color: black;
+}
+
 .section .section-header {
     font-size: 0.75rem;
     font-weight: 600;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,45 @@
+document.addEventListener("DOMContentLoaded", function(){
+  var toggle = document.getElementById("scheme-toggle");
+
+  var scheme = "light";
+  var savedScheme = localStorage.getItem("scheme");
+
+  var darkScheme = document.getElementById("dark-scheme");
+  var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+  if (prefersDark) {
+    scheme = "dark";
+  }
+
+  if(savedScheme) {
+    scheme = savedScheme;
+  }
+
+  if(scheme == "dark") {
+    darkscheme(toggle, darkScheme);
+  } else {
+    lightscheme(toggle, darkScheme);
+  }
+
+  toggle.addEventListener("click", () => {
+    if (toggle.className === "light") {
+      darkscheme(toggle, darkScheme);
+    } else if (toggle.className === "dark") {
+      lightscheme(toggle, darkScheme);
+    }
+  });
+});
+
+function darkscheme(toggle, darkScheme) {
+  localStorage.setItem("scheme", "dark");
+  toggle.innerHTML = feather.icons.sun.toSvg();
+  toggle.className = "dark";
+  darkScheme.disabled = false;
+}
+
+function lightscheme(toggle, darkScheme) {
+  localStorage.setItem("scheme", "light");
+  toggle.innerHTML = feather.icons.moon.toSvg();
+  toggle.className = "light";
+  darkScheme.disabled = true;
+}


### PR DESCRIPTION
Adds a dark mode toggle to the right side of the header, right after the social media icons:

<img width="871" alt="Screen Shot 2020-04-11 at 15 06 15" src="https://user-images.githubusercontent.com/854173/79044555-0b552980-7c06-11ea-9bdb-74593bd777ec.png">

<img width="874" alt="Screen Shot 2020-04-11 at 15 06 09" src="https://user-images.githubusercontent.com/854173/79044557-0d1eed00-7c06-11ea-8288-cbf787dfe91f.png">

The toggle is shown only when the `mode`  in the config file (e.g. `config.toml`) is set to `auto` or `dark`. 

It uses the `prefers-color-scheme` CSS media feature to detect if the user has requested the system to use a light or dark color scheme. Once it loads the preference, it saves it to the local storage of the client (browser), so the next time the user loads the website it will use the value from the local storage.

If the user clicks on the toggle, the new value is stored in the local storage.

FWIW, front-end is not my forte, so if you think there are some improvements to be made, please do let me know, I'd be happy to fix them.

---
## Screenshots

### iPhone X/XS

![Screen Shot 2020-04-11 at 15 19 53](https://user-images.githubusercontent.com/854173/79044855-05f8de80-7c08-11ea-8ee5-527180d896a1.png)
![Screen Shot 2020-04-11 at 15 19 45](https://user-images.githubusercontent.com/854173/79044857-072a0b80-7c08-11ea-8fdf-5608b5cb495a.png)

### iPad

![Screen Shot 2020-04-11 at 15 21 13](https://user-images.githubusercontent.com/854173/79044863-19a44500-7c08-11ea-8651-7c1914008f8b.png)
![Screen Shot 2020-04-11 at 15 21 09](https://user-images.githubusercontent.com/854173/79044864-1a3cdb80-7c08-11ea-8dba-39a544ee92c7.png)

---
### GIF

The toggle in action:

![screencast 2020-04-11 15-35-32](https://user-images.githubusercontent.com/854173/79045252-6be66580-7c0a-11ea-8222-03ce53511f19.gif)
