### PR TITLE
Fix dark theme switching by adding dark class to html tag

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html {{- if (eq .Site.Params.mode "dark") -}}class="dark"{{ end }}>
 {{ partial "header.html" . }}
 <body>
 	<div class="container wrapper">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,12 +27,11 @@
 	{{- if isset .Site.Params "customcss" }}
 		<link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}{{ .Site.Params.customCSS }}" />
 	{{ end }}
-	{{- if or (eq .Site.Params.mode "auto") (eq .Site.Params.mode "dark") -}}
-		<link id="dark-scheme" rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}css/dark.css" {{ if eq .Site.Params.mode "auto" }}media="(prefers-color-scheme: dark)"{{ end }} />
-		{{- if isset .Site.Params "customdarkcss" }}
-			<link id="dark-scheme" rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}{{ .Site.Params.customDarkCSS }}" {{ if eq .Site.Params.mode "auto" }}media="(prefers-color-scheme: dark)"{{ end }} />
-		{{- end }}
-	{{- end }}
+
+        <link id="dark-scheme" rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}css/dark.css" />
+        {{- if isset .Site.Params "customdarkcss" }}
+                <link id="dark-scheme" rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}{{ .Site.Params.customDarkCSS }}" />
+        {{- end }}
 
 	{{ if and (isset .Site.Params "social") (isset .Site.Params "feathericonscdn") (eq .Site.Params.featherIconsCDN true) -}}
 		<script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -1,66 +1,66 @@
-body {
-	color: #ddd;
-	background-color: #000;
+html.dark body {
+  color: #ddd;
+  background-color: #000;
 }
 
-::-moz-selection {
-	background: #9375fd;
-	color: #fff;
-    text-shadow: none
+html.dark ::-moz-selection {
+  background: #9375fd;
+  color: #fff;
+  text-shadow: none
 }
 
-::selection {
-	background: #9375fd;
-	color: #fff;
-    text-shadow: none
+html.dark ::selection {
+  background: #9375fd;
+  color: #fff;
+  text-shadow: none
 }
 
-hr {
-    border-color: #333;
+html.dark hr {
+  border-color: #333;
 }
 
-blockquote {
-	border-color: #ddd;
+html.dark blockquote {
+  border-color: #ddd;
 }
 
-h1,h2,h3,h4,h5,h6 {
-	color: #ddd;
+html.dark h1,h2,h3,h4,h5,h6 {
+  color: #ddd;
 }
 
-a,a:hover {
-	color: #9375fd;
-	text-decoration: none;
+html.dark a,a:hover {
+  color: #9375fd;
+  text-decoration: none;
 }
 
-table tbody tr:nth-of-type(even) {
+html.dark table tbody tr:nth-of-type(even) {
   background-color: rgba(255, 255, 255, 0.15);
 }
 
-.site-description a,
-.site-description a:hover {
-	color: #ddd;
-	text-decoration: underline;
+html.dark .site-description a,
+html.dark .site-description a:hover {
+  color: #ddd;
+  text-decoration: underline;
 }
 
-a:hover {
-	opacity: 0.8;
+html.dark a:hover {
+  opacity: 0.8;
 }
 
-.post-tags .tags a {
-    border: 1px solid #ddd;
-	color: #ddd;
+html.dark .post-tags .tags a {
+  border: 1px solid #ddd;
+  color: #ddd;
 }
 
-.site-title a {
-	color: #ddd;
-	text-decoration: none !important;
+html.dark .site-title a {
+  color: #ddd;
+  text-decoration: none !important;
 }
 
-.header nav,
-.footer {
-	border-color: #333;
+html.dark .header nav,
+html.dark .footer {
+  border-color: #333;
 }
 
-.highlight {
-	background-color: #333;
+html.dark .highlight {
+  background-color: #333;
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", function(){
   var scheme = "light";
   var savedScheme = localStorage.getItem("scheme");
 
-  var darkScheme = document.getElementById("dark-scheme");
+  var container = document.getElementsByTagName("html")[0];
   var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
 
   if (prefersDark) {
@@ -16,30 +16,30 @@ document.addEventListener("DOMContentLoaded", function(){
   }
 
   if(scheme == "dark") {
-    darkscheme(toggle, darkScheme);
+    darkscheme(toggle, container);
   } else {
-    lightscheme(toggle, darkScheme);
+    lightscheme(toggle, container);
   }
 
   toggle.addEventListener("click", () => {
     if (toggle.className === "light") {
-      darkscheme(toggle, darkScheme);
+      darkscheme(toggle, container);
     } else if (toggle.className === "dark") {
-      lightscheme(toggle, darkScheme);
+      lightscheme(toggle, container);
     }
   });
 });
 
-function darkscheme(toggle, darkScheme) {
+function darkscheme(toggle, container) {
   localStorage.setItem("scheme", "dark");
   toggle.innerHTML = feather.icons.sun.toSvg();
   toggle.className = "dark";
-  darkScheme.disabled = false;
+  container.className = "dark";
 }
 
-function lightscheme(toggle, darkScheme) {
+function lightscheme(toggle, container) {
   localStorage.setItem("scheme", "light");
   toggle.innerHTML = feather.icons.moon.toSvg();
   toggle.className = "light";
-  darkScheme.disabled = true;
+  container.className = "";
 }


### PR DESCRIPTION
The new theme switcher added in #14 works only when the browser sends the `prefers-color-scheme: dark`, as pointed out by @Dorson in [their comment](https://github.com/knadh/hugo-ink/pull/14#issuecomment-616897420).

This PR fixed that by adding a `dark` theme to the `html` tag. It also always includes the dark theme CSS, and the styles are controlled by the class on the `html` tag.