### PR TITLE
Fix dark theme headers CSS

### DIFF
--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -23,7 +23,12 @@ html.dark blockquote {
   border-color: #ddd;
 }
 
-html.dark h1,h2,h3,h4,h5,h6 {
+html.dark h1,
+html.dark h2,
+html.dark h3,
+html.dark h4,
+html.dark h5,
+html.dark h6 {
   color: #ddd;
 }
 


### PR DESCRIPTION
In #17 I made a mistake by incorrectly not nesting all heading styles under the `html.dark` selector, which lead to incorrect styles being applied to the `h2`-`h6` in light mode:

<img width="872" alt="Screenshot 2020-04-25 at 20 33 10" src="https://user-images.githubusercontent.com/854173/80287870-42fac000-8734-11ea-9cac-17f7d936fc2b.png">

This PR fixes this ☝️ 