### PR TITLE
Make the tags display more compact

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -27,11 +27,14 @@
 			<div class="tags">
 				{{ if ne .Type "page" }}
 					{{ if gt .Params.tags 0 }}
+                        <br>
 						<ul class="flat">
+                            Tags:
 							{{ range .Params.tags }}
-							<li><a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a></li>
+							<span><a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a></span>
 							{{ end }}
 						</ul>
+                        <br>
 					{{ end }}
 				{{ end }}
 			</div>


### PR DESCRIPTION
use <li takes too much space when there are many tags