### PR TITLE
Updates term.html to link to all pages with that term

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -6,7 +6,13 @@
 	<div class="container wrapper tags">
 		{{ partial "head.html" . }}
 
-		<h1 class="page-title">All tags</h1>
+		<h1 class="page-title">{{ .Title }}</h1>
+		
+		{{ with (.Site.GetPage .Title) }}
+			{{ range .Pages }}
+				<li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+			{{ end }}
+		{{ end }}
 	</div>
 
 	{{ partial "footer.html" . }}


### PR DESCRIPTION
I added content to term.html so that it's not empty but instead lists all pages with that taxonomy term.