### PR TITLE
Fix dark mode only

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html {{- if (eq .Site.Params.mode "dark") -}} {{ print " class=\"dark\"" | safeHTMLAttr}}{{ end }}>
 {{ partial "header.html" . }}
 
 <body>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html {{- if (eq .Site.Params.mode "dark") -}} {{ print " class=\"dark\"" | safeHTMLAttr}}{{ end }}>
 {{ partial "header.html" . }}
 <body>
 	<div class="container wrapper">

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html {{- if (eq .Site.Params.mode "dark") -}} {{ print " class=\"dark\"" | safeHTMLAttr}}{{ end }}>
 {{ partial "header.html" . }}
 
 <body>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html {{- if (eq .Site.Params.mode "dark") -}} {{ print " class=\"dark\"" | safeHTMLAttr}}{{ end }}>
 {{ partial "header.html" . }}
 
 <body>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html {{- if (eq .Site.Params.mode "dark") -}}class="dark"{{ end }}>
+<html{{- if (eq .Site.Params.mode "dark") -}} {{ print " class=\"dark\"" | safeHTMLAttr}}{{ end }}>
 {{ partial "header.html" . }}
 <body>
 	<div class="container wrapper">


### PR DESCRIPTION
Fix for issue #24 

Seems that spaces were not being preserved when HTML was rendered so the `<html>` turned into `<htmlclass="dark">`

Fixed by using `print` method