### PR TITLE
Show content of list page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,6 +11,8 @@
 		{{ else }}
 		<h2 class="page-title">{{ .Name }}</h2>
 		{{ end }}
+		
+		{{ .Content }}
 
 		<ul class="posts flat">
 			{{- range .Data.Pages -}}


### PR DESCRIPTION
Content can be added to list pages by creating a [_index.md file](https://gohugo.io/content-management/page-bundles/). This PR renders content below the page title, and above the posts list.