### PR TITLE
Apply safeURL to avatar

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,7 @@
 	{{ if .Site.Params.Avatar }}
 		<div class="avatar">
 			<a href="{{ .Site.BaseURL }}">
-				<img src="{{ .Site.Params.Avatar }}" alt="{{ .Site.Title }}" />
+				<img src="{{ .Site.Params.Avatar | safeURL }}" alt="{{ .Site.Title }}" />
 			</a>
 		</div>
 	{{ end }}


### PR DESCRIPTION
I made this change so I could set my avatar as a base64 string. This allows the image data to be included in the initial response for the page, rather than making an additional GET request to load the image.

[Here is an example of setting the avatar value to a base64 string.](https://git.robbyzambito.me/Zambyte/robbyzambito.me/src/commit/5b20818965716baefc4f56f48603fc3c4079703b/config.toml#L16)

This should not break existing behavior from my testing.