### PR TITLE
fix class when mode=dark is explicit

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
-<html {{- if (eq .Site.Params.mode "dark") -}}class="dark"{{ end }}>
+{{ if (eq .Site.Params.mode "dark") }}
+    <html class="dark">
+{{ else }}
+    <html>
+{{ end }}
+
 {{ partial "header.html" . }}
 <body>
 	<div class="container wrapper">


### PR DESCRIPTION
when mode is set to "dark" , hugo combines html tag and class attribute as `<htmlclass="dark">` instead of `<html class="dark">`. I was using hugo 0.80.0 on debian/buster-backports.