### PR TITLE
Fix issue #22 - unprocessed markdown in post previews

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,28 +19,7 @@
 			{{- if (in (.Site.Params.excludedTypes | default (slice "page")) .Type) -}}
 			{{- else -}}
 			<li class="post">
-				<div class="post-header">
-					<div class="meta">
-						<div class="date">
-							<span class="day">{{ dateFormat "02" .Date }}</span>
-							<span class="rest">{{ if $.Site.Data.month }}{{ index $.Site.Data.month (printf "%d" .Date.Month) }} {{ .Date.Year }}{{ else }}{{ dateFormat "Jan 2006" .Date }}{{ end }}</span>
-						</div>
-					</div>
-					<div class="matter">
-						<h4 class="title small">
-							<a href="{{ .RelPermalink }}">{{.Title}}{{ if .Draft }}<sup class="draft-label">DRAFT</sup>{{ end }}</a>
-						</h4>
-						<span class="description">
-							{{ if isset .Params "description" }}
-								{{ .Description }}
-							{{ else if gt (countrunes .RawContent) 120 }}
-								{{ slicestr .RawContent 0 120 }}...
-							{{ else }}
-								{{ .RawContent }}
-							{{ end }}
-						</span>
-					</div>
-				</div>
+				{{ partial "partials/post-preview.html" . }}
 			</li>
 			{{- end -}}
 			{{- end -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,7 +19,7 @@
 			{{- if (in (.Site.Params.excludedTypes | default (slice "page")) .Type) -}}
 			{{- else -}}
 			<li class="post">
-				{{ partial "partials/post-preview.html" . }}
+				{{ partial "post-preview.html" . }}
 			</li>
 			{{- end -}}
 			{{- end -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,28 +11,7 @@
 				{{ $paginator := .Paginate (where $pages "Params.hidden" "ne" true) }}
 				{{ range $paginator.Pages }}
 					<div class="post">
-						<div class="post-header">
-							<div class="meta">
-								<div class="date">
-									<span class="day">{{ dateFormat "02" .Date }}</span>
-							<span class="rest">{{ if $.Site.Data.month }}{{ index $.Site.Data.month (printf "%d" .Date.Month) }} {{ .Date.Year }}{{ else }}{{ dateFormat "Jan 2006" .Date }}{{ end }}</span>
-								</div>
-							</div>
-							<div class="matter">
-								<h4 class="title small">
-									<a href="{{ .RelPermalink }}">{{.Title}}{{ if .Draft }}<sup class="draft-label">DRAFT</sup>{{ end }}</a>
-								</h4>
-								<span class="description">
-									{{ if isset .Params "description" }}
-										{{ .Description }}
-									{{ else if gt (countrunes .RawContent) 120 }}
-										{{ slicestr .RawContent 0 120 }}...
-									{{ else }}
-										{{ .RawContent }}
-									{{ end }}
-								</span>
-							</div>
-						</div>
+						{{ partial "partials/post-preview.html" . }}
 					</div>
 				{{ end }}
 				{{ template "partials/paginator.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@
 				{{ $paginator := .Paginate (where $pages "Params.hidden" "ne" true) }}
 				{{ range $paginator.Pages }}
 					<div class="post">
-						{{ partial "partials/post-preview.html" . }}
+						{{ partial "post-preview.html" . }}
 					</div>
 				{{ end }}
 				{{ template "partials/paginator.html" . }}

--- a/layouts/partials/post-preview.html
+++ b/layouts/partials/post-preview.html
@@ -1,0 +1,22 @@
+<div class="post-header">
+	<div class="meta">
+		<div class="date">
+			<span class="day">{{ dateFormat "02" .Date }}</span>
+			<span class="rest">{{ if $.Site.Data.month }}{{ index $.Site.Data.month (printf "%d" .Date.Month) }} {{ .Date.Year }}{{ else }}{{ dateFormat "Jan 2006" .Date }}{{ end }}</span>
+		</div>
+	</div>
+	<div class="matter">
+		<h4 class="title small">
+			<a href="{{ .RelPermalink }}">{{.Title}}{{ if .Draft }}<sup class="draft-label">DRAFT</sup>{{ end }}</a>
+		</h4>
+		<span class="description">
+			{{ if isset .Params "description" }}
+				{{ .Description }}
+			{{ else if gt (countrunes .RawContent) 120 }}
+				{{ slicestr .RawContent 0 120 }}...
+			{{ else }}
+				{{ .RawContent }}
+			{{ end }}
+		</span>
+	</div>
+</div>

--- a/layouts/partials/post-preview.html
+++ b/layouts/partials/post-preview.html
@@ -12,10 +12,10 @@
 		<span class="description">
 			{{ if isset .Params "description" }}
 				{{ .Description }}
-			{{ else if gt (countrunes .RawContent) 120 }}
-				{{ slicestr .RawContent 0 120 }}...
+			{{ else if gt (countrunes (.Content | plainify)) 120 }}
+				{{ slicestr (.Content | plainify) 0 120 }}...
 			{{ else }}
-				{{ .RawContent }}
+				{{ .Content | plainify }}
 			{{ end }}
 		</span>
 	</div>


### PR DESCRIPTION
This addresses #22 for posts that do not have `.Description` set by using Hugo's `plainify` template method to extract plaintext from the Markdown's rendered HTML. Unlike either RawContent (Markdown) or Content (HTML), the plaintext can be truncated to 120 characters cleanly.